### PR TITLE
Add new constructor for DefaultPRNG

### DIFF
--- a/PoissonGenerator.h
+++ b/PoissonGenerator.h
@@ -23,6 +23,7 @@
 // Implementation based on http://devmag.org.za/2009/05/03/poisson-disk-sampling/
 
 /* Versions history:
+ 		1.1.3a		Jun  9, 2016		Update constructor for DefaultPRNG
  *		1.1.3		Mar 10, 2016		Header-only library, no global mutable state
  *		1.1.2		Apr  9, 2015		Output a text file with XY coordinates
  *		1.1.1		May 23, 2014		Initialize PRNG seed, fixed uninitialized fields
@@ -46,12 +47,17 @@ class DefaultPRNG
 {
 public:
 	DefaultPRNG()
-	: m_RD()
-	, m_Gen( m_RD() )
+	: m_Gen( std::random_device()() )
 	, m_Dis( 0.0f, 1.0f )
 	{
 		// prepare PRNG
 		m_Gen.seed( time( nullptr ) );
+	}
+
+	explicit DefaultPRNG( uint32_t seed )
+	: m_Gen( seed )
+	, m_Dis( 0.0f, 1.0f )
+	{
 	}
 
 	float RandomFloat()
@@ -66,7 +72,6 @@ public:
 	}
 
 private:
-	std::random_device m_RD;
 	std::mt19937 m_Gen;
 	std::uniform_real_distribution<float> m_Dis;
 };


### PR DESCRIPTION
In some system I would prefer to use a fixed seed for generator.
Would you please check if it is a valid change or whether there is alternative approach.

Thank you very much for you work.
